### PR TITLE
Fix esm module resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "repository": "github:lilyrose2798/trpc-openapi",
   "bugs": "https://github.com/lilyrose2798/trpc-openapi/issues",
   "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "module": "dist/esm/index.mjs",
   "typings": "dist/cjs/index.d.ts",
   "files": [
     "dist/cjs",
@@ -23,7 +23,7 @@
   "exports": {
     ".": {
       "require": "./dist/cjs/index.js",
-      "import": "./dist/esm/index.js",
+      "import": "./dist/esm/index.mjs",
       "types": "./dist/cjs/index.d.ts"
     }
   },


### PR DESCRIPTION
@LilyRose2798 

Somehow this slipped past my testing, but getting this error with 1.4.0 on Next 14.2.3
```
 ⨯ ModuleBuildError: ./src/pages/api/openapi.json.ts:1:1
Module not found: Can't resolve '@lilyrose2798/trpc-openapi'
> 1 | import { generateOpenApiDocument } from '@lilyrose2798/trpc-openapi'
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  2 | import { NextApiRequest, NextApiResponse } from 'next'
  3 | import { appRouter } from 'server/routers/root'
  4 |

Import map: aliased to relative "./src/@lilyrose2798/trpc-openapi" inside of [project]/

https://nextjs.org/docs/messages/module-not-found
```

The package.json was misconfigured so that the esm module entry was pointing to a non-existant file.

This PR fixes this issue.
