### PR TITLE
Unstable temporary support for tRPC 11

### DIFF
--- a/src/utils/procedure.ts
+++ b/src/utils/procedure.ts
@@ -30,12 +30,13 @@ const getProcedureType = (procedure: OpenApiProcedure): ProcedureType => {
   if (procedure._def.mutation) return 'mutation';
   if (procedure._def.subscription) return 'subscription';
 
-  if (procedure._def.type === 'query')
-    return 'query';
-  if (procedure._def.type === 'mutation')
-    return 'mutation';
-  if (procedure._def.type === 'subscription')
-    return 'subscription';
+  // tRPC 11 branches
+  // @ts-expect-error: tmp
+  if (procedure._def.type === 'query') return 'query';
+  // @ts-expect-error: tmp
+  if (procedure._def.type === 'mutation') return 'mutation';
+  // @ts-expect-error: tmp
+  if (procedure._def.type === 'subscription') return 'subscription';
 
   throw new Error('Unknown procedure type');
 };

--- a/src/utils/procedure.ts
+++ b/src/utils/procedure.ts
@@ -29,6 +29,14 @@ const getProcedureType = (procedure: OpenApiProcedure): ProcedureType => {
   if (procedure._def.query) return 'query';
   if (procedure._def.mutation) return 'mutation';
   if (procedure._def.subscription) return 'subscription';
+
+  if (procedure._def.type === 'query')
+    return 'query';
+  if (procedure._def.type === 'mutation')
+    return 'mutation';
+  if (procedure._def.type === 'subscription')
+    return 'subscription';
+
   throw new Error('Unknown procedure type');
 };
 


### PR DESCRIPTION
This PR attempts to add a fallback to temporarily support tRPC 11.

It seems the `procedure._def` structure has changed. I added a few more branches to the procedure type check in case the current ones fail.
`Error: Unknown procedure type: "query"`

Not sure if this is the way to go. But since the main repository seems dead I figured we could make do with this for the moment.

Looking to contribute further. Many thanks!